### PR TITLE
Update readme & dockerfile to use Maxfuzz stable release

### DIFF
--- a/Dockerfile_stable
+++ b/Dockerfile_stable
@@ -1,5 +1,5 @@
 # Dockerfile using stable Maxfuzz image
-# TODO: FROM Image on docker hub
+FROM coinbase/maxfuzz@sha256:f633dc8c2aff035f3e7668c83133dbb6fa7e9bf4372e6a28c2d8f86177385af6
 
 WORKDIR /root/fuzzer-files
 COPY ./fuzzers/ ./

--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ This guide assumes you have Docker, docker-compose and make installed. For more 
 
 ## 🐞 Find your first bug
 
-First, build the base Maxfuzz Docker image: `make build`
-
-Then spin up a local instance of Maxfuzz, running some [sample fuzzers](fuzzers/README.md): `make deploy-dev`
+First, spin up a local instance of Maxfuzz, running some [sample fuzzers](fuzzers/README.md): `make deploy-stable`
 
 This launches a basic fuzzer that fuzzes some vulnerable C code, which can be found in `./fuzzers/vulnerable/`.
 


### PR DESCRIPTION
Make the stable release the default in README to reduce build/wait time.